### PR TITLE
modelbase_detail inclusion template now has a block for easier re-use

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+next
+----
+#. `modelbase_detail` inclusion template now has a block for easier re-use.
+
 0.5.4
 -----
 #. Pin Django on 1.4.x range.

--- a/jmbo/templates/jmbo/inclusion_tags/modelbase_detail.html
+++ b/jmbo/templates/jmbo/inclusion_tags/modelbase_detail.html
@@ -1,5 +1,11 @@
 <div class="object-detail-inclusion {{ object.class_name.lower }}-detail-inclusion">
-    {% if object.image %}
-        <img src="{{ object.image_detail_url }}" />
-    {% endif %}
+    {% block content %}
+        {% if object.image %}
+            <img src="{{ object.image_detail_url }}" />
+        {% endif %}
+        {% if object.description %}
+            <p>{{ object.description|linebreaks }}</p>
+        {% endif %}
+    {% endblock %}    
+    <div class="clear"></div>
 </div>


### PR DESCRIPTION
modelbase_detail inclusion template now has a block for easier re-use.
