### PR TITLE
Add in categorised and SEO fixes

### DIFF
--- a/jmbo/models.py
+++ b/jmbo/models.py
@@ -251,6 +251,33 @@ but users won't be able to add new likes."),
             # Fallback
             return reverse('object_detail', args=[self.slug])
 
+    def get_absolute_url_categorized(self):
+        """Absolute url with category.
+
+        Provides a hook to get an url for an object, connected to a category,
+        but just reusing the get_absolute_url templates etc.
+        """
+        category_slug = None
+        if self.primary_category:
+            category_slug = self.primary_category.slug
+        elif self.categories.all().exists():
+            category_slug = self.categories.all()[0].slug
+
+        if category_slug:
+            try:
+                return reverse(
+                    '%s_categorized_object_detail' \
+                        % self.as_leaf_class().__class__.__name__.lower(),
+                    kwargs={'category_slug': category_slug, 'slug': self.slug}
+                )
+            except NoReverseMatch:
+                # No generic modelbase fallback: Allow get_absolute_url to
+                # take over.
+                pass
+
+        # Sane fallback if no category
+        return self.get_absolute_url()
+
     def save(self, *args, **kwargs):
         now = timezone.now()
 

--- a/jmbo/templates/jmbo/inclusion_tags/modelbase_list_item.html
+++ b/jmbo/templates/jmbo/inclusion_tags/modelbase_list_item.html
@@ -1,3 +1,3 @@
 <div class="title">
-    <a href="{{ object.get_absolute_url }}">{{ object.title }}</a>
+    <a href="{{ object.get_absolute_url_categorized }}" title="{{ object.title|escape }}">{{ object.title }}</a>
 </div>

--- a/jmbo/templates/jmbo/modelbase_detail.html
+++ b/jmbo/templates/jmbo/modelbase_detail.html
@@ -5,6 +5,7 @@
 
 {% block extrameta %}
     {% jmbocache 1200 'object-detail' object.id object.modified %}
+        <link rel="canonical" href="{{ object.get_absolute_url }}" />
         <meta name="description" content="{{ object.description|default_if_none:'' }}" />
         {% with object.tags.all as tags %}
             {% if tags %}


### PR DESCRIPTION
Ported SEO fixes from 1.4 (develop branch).

I did not include the special case as was added to get_absolute_url, since get_absolute_url is the fallback in any case.