### PR TITLE
Explicitly add fields = '__all__' to Serializers

### DIFF
--- a/jmbo/api/__init__.py
+++ b/jmbo/api/__init__.py
@@ -45,6 +45,7 @@ class ModelBaseSerializer(
     class Meta:
         model = ModelBase
         admin = ModelBaseAdmin
+        fields = "__all__"
 
     def get_extra_kwargs(self):
         # We specify a base_name at router registration and this is a way to
@@ -91,6 +92,7 @@ class ImageSerializer(HyperlinkedModelSerializer):
 
     class Meta:
         model = Image
+        fields = "__all__"
 
 
 class ImageViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
... because
```
(u"Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since 3.3.0, and is now disallowed. Add an explicit fields = '__all__' to the ImageSerializer serializer.",)
```